### PR TITLE
Admin options to set applicable countries

### DIFF
--- a/app/code/community/Meanbee/Shippingrules/etc/config.xml
+++ b/app/code/community/Meanbee/Shippingrules/etc/config.xml
@@ -93,6 +93,7 @@
                 <condense_countries_on_grid>flag</condense_countries_on_grid>
                 <colapse_conditions_on_subcondition_on_grid>1</colapse_conditions_on_subcondition_on_grid>
                 <use_emoji_one>1</use_emoji_one>
+                <sallowspecific>0</sallowspecific>
             </meanship>
         </carriers>
     </default>

--- a/app/code/community/Meanbee/Shippingrules/etc/system.xml
+++ b/app/code/community/Meanbee/Shippingrules/etc/system.xml
@@ -93,6 +93,26 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </collapse_conditions_on_subcondition_on_grid>
+                        <sallowspecific translate="label">
+                            <label>Ship to Applicable Countries</label>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>100</sort_order>
+                            <frontend_class>shipping-applicable-country</frontend_class>
+                            <source_model>adminhtml/system_config_source_shipping_allspecificcountries</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </sallowspecific>
+                        <specificcountry translate="label">
+                            <label>Ship to Specific Countries</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <sort_order>101</sort_order>
+                            <source_model>adminhtml/system_config_source_country</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <can_be_empty>1</can_be_empty>
+                        </specificcountry>
                     </fields>
                 </meanship>
             </groups>


### PR DESCRIPTION
Resolves issue #2 

Adding the admin settings is all that is needed to optionally restrict the shipping rules to only the defined countries. The logic is handled automatically in Mage_Shipping_Model_Carrier_Abstract.