### PR TITLE
- fixed addPaymentDataToRequest method, adding data to request instead of quote

### DIFF
--- a/app/code/community/Meanbee/Shippingrules/Model/Carrier.php
+++ b/app/code/community/Meanbee/Shippingrules/Model/Carrier.php
@@ -327,7 +327,7 @@ class Meanbee_Shippingrules_Model_Carrier extends Mage_Shipping_Model_Carrier_Ab
         $requestItems = $request->getAllItems();
         if (count($requestItems) > 0) {
             $quote = $requestItems[0]->getQuote();
-            $quote->setData('payment_method', $quote->getPayment()->getMethod());
+            $request->setData('payment_method', $quote->getPayment()->getMethod());
         }
         return $request;
     }


### PR DESCRIPTION
Hi, thank you for this great plugin. I tried to use it with payment method conditions, which I suppose is not used very often, as stated in documentation: https://meanbee.atlassian.net/wiki/spaces/EXT/pages/35160074/Shipping+Rules#ShippingRules-Conditions in payment conditions section. However, even after changing checkout flow, so payment method is selected before shipping method it did not work properly. I found out that getSanitisedValue method of Meanbee_Shippingrules_Model_Rule_Condition returns null for payment_method attribute, and then I found, that payment_method data is not saved to $request, but to $quote in Carrier model. I think it's a typo, and since this functionality is not 100% in scope of extension no one found it before, but maybe it will be useful for someone in the future.